### PR TITLE
Rewrite grabbing: velocity for movement, E to grab 

### DIFF
--- a/Assets/Scenes/LevelOne/Copy.unity
+++ b/Assets/Scenes/LevelOne/Copy.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18029143, g: 0.22572419, b: 0.30693057, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3852,6 +3852,7 @@ MonoBehaviour:
     type: 3}
   HUDPrefab: {fileID: 1692916813957765883, guid: 5d966ed67409f05409fa0c6f315671f6,
     type: 3}
+  PauseMenuPrefab: {fileID: 0}
   spawnPoint: {fileID: 1677701967}
   isAlive: 1
   controlEnabled: 1
@@ -10033,6 +10034,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: FallingEntity (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 1077755463841450474, guid: ddcbf85da42714327967bca20bca509a,
+        type: 3}
+      propertyPath: m_UseGravity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1077755463841450474, guid: ddcbf85da42714327967bca20bca509a,
+        type: 3}
+      propertyPath: m_Interpolate
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1077755463841450474, guid: ddcbf85da42714327967bca20bca509a,
+        type: 3}
+      propertyPath: m_IsKinematic
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1077755463841450474, guid: ddcbf85da42714327967bca20bca509a,
+        type: 3}
+      propertyPath: m_CollisionDetection
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8368184150863724729, guid: ddcbf85da42714327967bca20bca509a,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -10101,8 +10122,31 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 613805950313400647, guid: ddcbf85da42714327967bca20bca509a,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1983911350}
   m_SourcePrefab: {fileID: 100100000, guid: ddcbf85da42714327967bca20bca509a, type: 3}
+--- !u!1 &1983911343 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 613805950313400647, guid: ddcbf85da42714327967bca20bca509a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1980658858}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1983911350
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1983911343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172d926b228a88889966ad31497a7249, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MagicGrabMoveSpeedNumber: 20
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Interactables/GrabbedController.cs
+++ b/Assets/Scripts/Interactables/GrabbedController.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+public class GrabbedController : MonoBehaviour, IInteractable
+{
+    private InputManager _input;
+    private bool stillHasNotReleasedThaMofoButton;
+    private bool grabbed = false;
+    private float grabOffset;
+    private Rigidbody rb;
+    private float size;
+    private bool initialized = false;
+    public float MagicGrabMoveSpeedNumber = 20f; //this REALLY should not be a per object (on component) variable lmaooo!!!! (if we want it tweakable in editor)
+    private float cameraHeight = 1.375f;
+
+    void WoweeMeGotGrabd() {
+        if (_input == null || grabOffset == null || rb == null) {
+            GameObject player = GameObject.FindGameObjectWithTag("Player");
+            _input = player.GetComponent<InputManager>();
+            grabOffset = player.GetComponent<PlayerInteract>().InteractionRange;
+            rb = GetComponent<Rigidbody>();
+        }
+
+        Vector3 bounds = GetComponent<Renderer>().bounds.extents;
+        size = Mathf.Max(bounds.x, Mathf.Max(bounds.y, bounds.z)); //we wanna be able to grab big objects without them going inside us (UWU)
+        grabbed = true;
+        stillHasNotReleasedThaMofoButton = true;
+        initialized = true;
+    }
+
+    void MeFreee() {
+        grabbed = false;
+    }
+
+    public void Interact() {
+        if (!stillHasNotReleasedThaMofoButton && !grabbed) {
+            WoweeMeGotGrabd();
+        }
+    }
+
+    void ApplyGrab() {
+        Vector3 toPos = Camera.main.transform.position + Camera.main.transform.forward * (grabOffset + size);
+        toPos.y = Mathf.Max(toPos.y, Camera.main.transform.position.y - cameraHeight + size);
+        Vector3 vecToPos = toPos - rb.position;
+        rb.velocity = vecToPos * 15;
+        //rb.MovePosition(toPos);
+    }
+
+    void Update() {
+        if (initialized) {
+            if (stillHasNotReleasedThaMofoButton && !(_input.IsInteracting())) {
+                stillHasNotReleasedThaMofoButton = false;
+            }
+            if (grabbed) {
+                if (!stillHasNotReleasedThaMofoButton && _input.IsInteracting()) {
+                    stillHasNotReleasedThaMofoButton = true;
+                    MeFreee(); //you are free now! Run, box, run!
+                }
+                ApplyGrab();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Interactables/GrabbedController.cs.meta
+++ b/Assets/Scripts/Interactables/GrabbedController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 172d926b228a88889966ad31497a7249
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
solves #3

**TL;DR:**

**Grab with E, grab snappier, same bugs as before but they are weaker**

All grabbables now need a GrabbedController script attached to them!

One of the boxes in the Copy level (the box lying on ground) has this
already.

Grabbing now uses E, same as Interact, through the IInteractable iface.

It's kinda :skull: that I did all this in one single file without changing
any of our other scripts or any of our input logic. The
PlayerInteract.cs script is really not made for interacting with objects
where the interaction happens over time with several instances of input
(i.e. grab and then ungrab on the same object, without having to look at
it to ungrab)

We can remove the old GrabManager.cs when we merge this. Except:

One thing missing compared to GrabManager is that objects are not
automatically dropped if they go out of range or start to be rewinded!
One feedback we got on that is that the interaction wasn't clear. So how
should it be??

Grabbed objects are now moved by setting a constant velocity instead of
applying force. This makes it a lot snappier than before.

~~One thing that is still a bit shite is that grabbed objects slightly
jitter (much less than before) while walking with them in your hand. I
think this is due to their physics updating at a slightly different
timing to the player. I tried various ways of setting the object
position and all had this problem: rb.position, rb.MovePosition(), and
lastly rb.velocity. I think the only way to fix this might be to either
go deep in the physics simulation logic and fix the timings, or we make
grabbed objects a child of the player (but then how handle collisions?).
I also tried to mess with interpolation settings on grabbed objects to
see if it solved the jittering, which it did not seem to do.~~
Set Interpolate on all RigidBodies that will be grabbed! The script should
probably set this for you...

To fix issues with friction (objects dragged along floor) when moving
while holding I now clamp grabbed objects position to slightly above the
player's feet.

And also grabbing of objects now takes into account their size, so you
maintain a distance of 2.0f to the nearest edge of the grabbed object
instead of the center! This lets you grab big stuff without impeding
yourself.

~~The grab-flying exploit is still in the game, but much harder to do. The
only reason it still works I believe is because you can jump on an
object while holding it (Newton's whichever law it was hello????). So we
just gotta check that in the jump function ig.~~
Edit: I think it might be too hard to actually do atm, kinda fine?

Oh and excuse the variable and function names.