### PR TITLE
fix hatch animation, make rewind stop grab

### DIFF
--- a/Assets/Prefabs/Environment/Hatch.prefab
+++ b/Assets/Prefabs/Environment/Hatch.prefab
@@ -73,7 +73,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   animator: {fileID: 5091119925311431586}
   doorAnimation: {fileID: 7400000, guid: 9e2c36212f563647aa3ef7006f9e6b6f, type: 2}
-  isOpen: 1
+  isOpen: 0
   animationProgress: 0
   animationSpeed: 1
   openSound: {fileID: 8300000, guid: ec0c74be74c1dcb85ae01cfbe0972747, type: 3}
@@ -108,6 +108,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioSource: {fileID: 0}
+  timeEntity: {fileID: 0}
   audioClip: {fileID: 0}
   playbackTime: 0
 --- !u!1001 &2534484217256533506

--- a/Assets/Scripts/Environment/DoorController.cs
+++ b/Assets/Scripts/Environment/DoorController.cs
@@ -24,6 +24,7 @@ public class DoorController : MonoBehaviour
         {
             Debug.Log("No time entity found for door.");
         }
+        SetDoorAnimation(animationProgress); //make sure it starts in the right position and isnt playing the animation on repeat
     }
 
     void Start()
@@ -41,11 +42,11 @@ public class DoorController : MonoBehaviour
         {
             if (isOpen)
             {
-                animationProgress = Mathf.Clamp(animationProgress + Time.deltaTime * animationSpeed, 0, 1);
+                animationProgress = Mathf.Clamp(animationProgress + Time.deltaTime * animationSpeed, 0, 0.999999f);
             }
             else
             {
-                animationProgress = Mathf.Clamp(animationProgress - Time.deltaTime * animationSpeed, 0, 1);
+                animationProgress = Mathf.Clamp(animationProgress - Time.deltaTime * animationSpeed, 0, 0.999999f);
             }
         }
 

--- a/Assets/Scripts/Interactables/GrabbedController.cs
+++ b/Assets/Scripts/Interactables/GrabbedController.cs
@@ -12,6 +12,11 @@ public class GrabbedController : MonoBehaviour, IInteractable
     private bool initialized = false;
     public float MagicGrabMoveSpeedNumber = 20f; //this REALLY should not be a per object (on component) variable lmaooo!!!! (if we want it tweakable in editor)
     private float cameraHeight = 1.375f;
+    private TimeEntity tent;
+
+    void Start() {
+        tent = GetComponent<TimeEntity>();
+    }
 
     void WoweeMeGotGrabd()
     {
@@ -37,7 +42,7 @@ public class GrabbedController : MonoBehaviour, IInteractable
 
     public void Interact()
     {
-        if (!stillHasNotReleasedThaMofoButton && !grabbed)
+        if (!stillHasNotReleasedThaMofoButton && !grabbed && !tent.IsRewinding)
         {
             WoweeMeGotGrabd();
         }
@@ -67,6 +72,9 @@ public class GrabbedController : MonoBehaviour, IInteractable
                 {
                     stillHasNotReleasedThaMofoButton = true;
                     MeFreee(); //you are free now! Run, box, run!
+                }
+                if (tent.IsRewinding) {
+                    MeFreee();
                 }
                 ApplyGrab();
             }


### PR DESCRIPTION
kinda weird to do both in one PR but sry

The ONLY change to the Hatch prefab is to toggle the "isOpen" property on the DoorController component

Turns out setting animationprogress to 1.0 is out of bounds, so now we use 0.999999f instead.

Also PLEASE don't look in the GrabbedController code :)